### PR TITLE
feat: add support for repos limited to https only

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click==8.1.3
-python-gitlab==2.10.1
+python-gitlab==3.15.0
 MarkupSafe==2.1.1
 Jinja2==3.1.2
 PyYAML==5.4.1

--- a/src/pyslurp/configuration/autoconfig.py
+++ b/src/pyslurp/configuration/autoconfig.py
@@ -59,7 +59,6 @@ def _generate_local_config(env):
         data = file.read().replace('\n', '')
         host = re.search("(?:git@|https?://)([^/:]+)", data).group(1)
         path = re.search("(?:git@[^:]+:|https?://[^/]+/)(.+).git", data).group(1)
-        print(path)
         secure_host = f"https://{host}/"
         local_config = local_config_template.render(
             gitlab_key=GITLAB_CONFIG_KEY,

--- a/src/pyslurp/configuration/autoconfig.py
+++ b/src/pyslurp/configuration/autoconfig.py
@@ -57,12 +57,10 @@ def _generate_local_config(env):
     local_config_template = template_env.get_template(".pyslurp.j2")
     with open(find_config(GIT_CONFIG_FILE_NAME), 'r', encoding="utf-8") as file:
         data = file.read().replace('\n', '')
-        git_config_uri = re.match(".*(url = git@)(.*:.*)(.*\\.git)", data)
-        git_uri = git_config_uri[2]
-        git_uri_components = git_uri.split(":")
-        host = git_uri_components[0]
+        host = re.search("(?:git@|https?://)([^/:]+)", data).group(1)
+        path = re.search("(?:git@[^:]+:|https?://[^/]+/)(.+).git", data).group(1)
+        print(path)
         secure_host = f"https://{host}/"
-        path = git_uri_components[1]
         local_config = local_config_template.render(
             gitlab_key=GITLAB_CONFIG_KEY,
             gitlab_url_key=GITLAB_URL_KEY,


### PR DESCRIPTION
Lately I ran into a problem with a client, who does not support SSH on their GitLab. Instead everything goes via SSO + HTTPS.
Hence, the config routine of the slurper was unable to parse the URL from the config in the .git dir.
This MR should fix it.